### PR TITLE
Adding extra backslash for Windows configuration.

### DIFF
--- a/plsql-language-custom/xyz.plsql-language-custom-0.0.1/README.md
+++ b/plsql-language-custom/xyz.plsql-language-custom-0.0.1/README.md
@@ -4,6 +4,6 @@ This is an exemple for some custom colorization.
 
 1. Modify **syntaxes\plsql-custom.tmlanguage** with some custom definitions
 2. Copy folder **xyz.plsql-language-custom-0.0.1** in extensions, according to your platform:
-    - **Windows** %USERPROFILE%\.vscode\extensions
+    - **Windows** %USERPROFILE%\\.vscode\extensions
     - **Mac** ~/.vscode/extensions
     - **Linux** ~/.vscode/extensions


### PR DESCRIPTION
Or else Markdown removes it and copy/paste is not working